### PR TITLE
Add way to fill missing pics

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -7,6 +7,7 @@
 #include "sound_manager.h"
 #include "game.h"
 #include "duelclient.h"
+#include "fillpics.h"
 
 namespace ygo {
 
@@ -94,6 +95,7 @@ void DeckBuilder::Initialize() {
 	mainGame->btnSideSort->setVisible(false);
 	mainGame->btnSideReload->setVisible(false);
 	mainGame->btnGenerateScript->setVisible(true);
+	mainGame->btnFillPic->setVisible(true);
 	if (mainGame->gameConf.use_lflist) {
 		if (mainGame->gameConf.default_lflist >= 0 && mainGame->gameConf.default_lflist < (int)deckManager._lfList.size()) {
 			filterList = &deckManager._lfList[mainGame->gameConf.default_lflist];
@@ -136,6 +138,8 @@ void DeckBuilder::Terminate() {
 	mainGame->btnBigCardZoomOut->setVisible(false);
 	mainGame->btnBigCardClose->setVisible(false);
 	mainGame->btnGenerateScript->setVisible(false);
+	mainGame->btnFillPic->setVisible(false);
+	mainGame->progressFillPic->setVisible(false);
 	EnableEditWindow(true);
 	EnableManageWindow(true);
 	mainGame->ResizeChatInputWindow();
@@ -1099,6 +1103,20 @@ void DeckBuilder::ButtonHandler(const irr::SEvent& event) {
 			mainGame->stACMessage->setText(dataManager.GetSysString(1801));
 			mainGame->PopupElement(mainGame->wACMessage, 40);
 		}
+		break;
+	}
+	case BUTTON_FILL_PIC: {
+#if _WIN32
+		mainGame->progressFillPic->setText(dataManager.GetSysString(1803));
+		mainGame->progressFillPic->setVisible(true);
+		mainGame->env->drawAll();
+		std::thread t([&]() {
+			fillpics fp("cards.cdb");
+			fp.get_card_size();
+			fp.fetch_and_fill_pic();
+			});
+		t.detach();
+#endif
 		break;
 	}
 	}

--- a/gframe/fillpics.cpp
+++ b/gframe/fillpics.cpp
@@ -1,0 +1,141 @@
+#if _WIN32
+#include "fillpics.h"
+#include "data_manager.h"
+#include "game.h"
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <windows.h>
+
+typedef long long sqlite3_int64;
+typedef struct sqlite3 sqlite3;
+typedef struct sqlite3_stmt sqlite3_stmt;
+
+typedef HRESULT (WINAPI *URLDownloadToFileA_fn)(void*, const char*, const char*, DWORD, void*);
+
+namespace ygo{
+    
+bool fillpics::has_pic(sqlite3_int64 id) {
+    const std::string pic_path = "pics";
+    return std::ifstream(pic_path + "/" + std::to_string(id) + ".jpg").good();
+}
+
+bool fillpics::download_pic(sqlite3_int64 id) {
+    if(pic_source_url == "") return false;
+
+    const std::string download_url = pic_source_url + std::to_string(id) + ".jpg";
+    const std::string savepath = "pics/" + std::to_string(id) + ".jpg";
+
+    HMODULE urlmon = LoadLibraryA("urlmon.dll");
+    if (!urlmon) {
+        char error_msg[] = "Failed to load urlmon.dll\n";
+        mainGame->ErrorLog(error_msg);
+        return false;
+    }
+
+    URLDownloadToFileA_fn pURLDownloadToFileA =
+        (URLDownloadToFileA_fn)GetProcAddress(urlmon, "URLDownloadToFileA");
+    if (!pURLDownloadToFileA) {
+        char error_msg[] = "Failed to get URLDownloadToFileA\n";
+		mainGame->ErrorLog(error_msg);
+        FreeLibrary(urlmon);
+        return false;
+    }
+
+    HRESULT hr = pURLDownloadToFileA(nullptr, download_url.c_str(), savepath.c_str(), 0, nullptr);
+    FreeLibrary(urlmon);
+
+    if (FAILED(hr)) {
+		char error_msg[128];
+		sprintf(error_msg, "Failed id %lld, error code 0x%08X, url:%s\n", id, static_cast<unsigned long>(hr), download_url.c_str());
+        mainGame->ErrorLog(error_msg);
+        return false;
+    }
+
+    return true;
+}
+
+bool fillpics::getCardDb(std::string s)
+{
+    if (sqlite3_open(db_path.c_str(), &db) != SQLITE_OK) {
+        if (db) {
+            sqlite3_close(db);
+        }
+        return false;
+    }
+    return true;
+}
+
+sqlite3_int64 fillpics::get_card_size()
+{
+    sqlite3_stmt* stmt_getsize;
+    const char* sql_getsize = "SELECT COUNT(*) FROM texts;";
+    if (sqlite3_prepare_v2(db, sql_getsize, -1, &stmt_getsize, nullptr) != SQLITE_OK) {
+        sqlite3_close(db);
+        return false;
+    }
+    const int rc = sqlite3_step(stmt_getsize);
+    if (rc == SQLITE_ROW) {
+        card_size = sqlite3_column_int64(stmt_getsize, 0);
+    }
+	return card_size;
+}
+
+bool fillpics::fetch_and_fill_pic(std::string qry)
+{
+    if (pic_source_url == "" || pic_source_url == "N") {
+		std::wstring wmsg = dataManager.GetSysString(1804);
+		mainGame->progressFillPic->setText(wmsg.c_str());
+		return false;
+    }
+    const wchar_t* msg_prefix = dataManager.GetSysString(1803);
+    std::wstring wmsg_prefix(msg_prefix);
+    sqlite3_stmt* stmt = nullptr;
+    const char* sql = qry.c_str();
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        sqlite3_close(db);
+        return false;
+    }
+	uint16_t progress = 0;
+    while (true) {
+
+        const int rc = sqlite3_step(stmt);
+        sqlite3_int64 id = 0;
+        progress++;
+        if (rc == SQLITE_ROW) {
+            id = sqlite3_column_int64(stmt, 0);
+        } else if (rc == SQLITE_DONE) {
+            break;
+        } else {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return false;
+        }
+        std::wstring progress_msg = wmsg_prefix + L" " + std::to_wstring(progress) + L"/" + std::to_wstring(card_size);
+		mainGame->progressFillPic->setText(progress_msg.c_str());
+        if (!has_pic(id)) {
+            download_pic(id);
+        }
+    }
+    sqlite3_finalize(stmt);
+    return true;
+}
+
+// getCardDb => prepare stmt
+fillpics::fillpics(std::string dbPath) {
+    db = NULL;
+    db_path = dbPath;
+	getCardDb(dbPath);
+    std::wstring ws(mainGame->gameConf.pic_source_url);
+	pic_source_url = std::string(ws.begin(), ws.end());
+}
+
+fillpics::~fillpics(){
+    if(db != NULL)
+        sqlite3_close(db);
+    
+}
+
+}
+
+#endif

--- a/gframe/fillpics.h
+++ b/gframe/fillpics.h
@@ -1,0 +1,31 @@
+#ifndef FILLPICS_H
+#define FILLPICS_H
+
+#if _WIN32
+
+#include <iostream>
+#include <sqlite3.h>
+
+namespace ygo{
+class fillpics
+{
+    private:
+        sqlite3* db;
+        std::string pic_source_url;
+        std::string db_path;
+        bool getCardDb(std::string path);
+		sqlite3_int64 card_size;
+    public:
+        bool download_pic(sqlite3_int64 id);
+        sqlite3_int64 get_card_size();
+        bool fetch_and_fill_pic(std::string qry = "SELECT id FROM texts;");
+        bool has_pic(sqlite3_int64 id);
+        fillpics(std::string dbPath);
+        ~fillpics();
+};
+    
+
+}
+
+#endif
+#endif

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -712,6 +712,11 @@ bool Game::Initialize() {
 	btnSideReload->setVisible(false);
 	btnGenerateScript = env->addButton(irr::core::rect<irr::s32>(205, 100, 295, 135), 0, BUTTON_GENERATE_SCRIPT, dataManager.GetSysString(1800));
 	btnGenerateScript->setVisible(false);
+	btnFillPic = env->addButton(irr::core::rect<irr::s32>(205, 155, 295, 185), 0, BUTTON_FILL_PIC, dataManager.GetSysString(1802));
+	btnFillPic->setVisible(false);
+	progressFillPic = env->addStaticText(L"Hello", irr::core::rect<irr::s32>(205, 195, 295, 225), true, true);
+	progressFillPic->setBackgroundColor(0xc0c0c0ff);
+	progressFillPic->setVisible(false);
 	//
 	scrFilter = env->addScrollBar(false, irr::core::recti(999, 161, 1019, 629), 0, SCROLL_FILTER);
 	scrFilter->setLargeStep(10);
@@ -1441,7 +1446,13 @@ void Game::LoadConfig() {
 		} else if(!std::strcmp(strbuf, "music_mode")) {
 			gameConf.music_mode = std::strtol(valbuf, nullptr, 10);
 #endif
-		} else {
+		}
+#if _WIN32
+		else if (!std::strcmp(strbuf, "pic_source_url")) {
+			BufferIO::DecodeUTF8(valbuf, gameConf.pic_source_url);
+		}
+#endif // _WIN32 
+		else {
 			// options allowing multiple words
 			if (std::sscanf(linebuf, "%63s = %959[^\n]", strbuf, valbuf) != 2)
 				continue;
@@ -1469,6 +1480,7 @@ void Game::LoadConfig() {
 			} else if(!std::strcmp(strbuf, "bot_deck_path")) {
 				BufferIO::DecodeUTF8(valbuf, gameConf.bot_deck_path);
 			}
+
 		}
 	}
 	std::fclose(fp);
@@ -1538,6 +1550,10 @@ void Game::SaveConfig() {
 	std::fprintf(fp, "window_width = %d\n", gameConf.window_width);
 	std::fprintf(fp, "window_height = %d\n", gameConf.window_height);
 	std::fprintf(fp, "resize_popup_menu = %d\n", gameConf.resize_popup_menu ? 1 : 0);
+#if _WIN32
+	BufferIO::EncodeUTF8(gameConf.pic_source_url, linebuf);
+	std::fprintf(fp, "pic_source_url = %s\n", linebuf);
+#endif
 #ifdef YGOPRO_USE_AUDIO
 	std::fprintf(fp, "enable_sound = %d\n", (chkEnableSound->isChecked() ? 1 : 0));
 	std::fprintf(fp, "enable_music = %d\n", (chkEnableMusic->isChecked() ? 1 : 0));
@@ -2076,7 +2092,8 @@ void Game::OnResize() {
 	btnBigCardZoomOut->setRelativePosition(Resize(205, 180, 295, 215));
 	btnBigCardClose->setRelativePosition(Resize(205, 230, 295, 265));
 	btnGenerateScript->setRelativePosition(Resize(205, 100, 295, 135));
-
+	btnFillPic->setRelativePosition(Resize(205, 140, 295, 175));
+	progressFillPic->setRelativePosition(Resize(205, 180, 295, 215));
 	irr::s32 barWidth = (xScale > 1) ? gameConf.textfontsize * xScale : gameConf.textfontsize;
 	env->getSkin()->setSize(irr::gui::EGDS_SCROLLBAR_SIZE, barWidth);
 }

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -71,6 +71,7 @@ struct Config {
 	wchar_t textfont[256]{};
 	wchar_t numfont[256]{};
 	wchar_t bot_deck_path[256]{ L"./WindBot/Decks" };
+	wchar_t pic_source_url[128];
 	//settings
 	int chkMAutoPos{ 0 };
 	int chkSTAutoPos{ 1 };
@@ -555,7 +556,9 @@ public:
 	irr::gui::IGUIButton* btnSideSort;
 	irr::gui::IGUIButton* btnSideReload;
 	irr::gui::IGUIButton* btnGenerateScript;
+	irr::gui::IGUIButton* btnFillPic;
 	irr::gui::IGUIEditBox* ebDeckname;
+	irr::gui::IGUIStaticText* progressFillPic;
 	irr::gui::IGUIStaticText* stDBCategory;
 	irr::gui::IGUIStaticText* stDeck;
 	irr::gui::IGUIStaticText* stCategory;
@@ -883,6 +886,8 @@ extern Game* mainGame;
 #define BUTTON_MARKERS_OK			469
 
 #define BUTTON_GENERATE_SCRIPT		500
+
+#define BUTTON_FILL_PIC				501
 
 #define AVAIL_OCG					0x1
 #define AVAIL_TCG					0x2

--- a/strings.conf
+++ b/strings.conf
@@ -538,6 +538,9 @@
 #custom
 !system 1800 Test Script
 !system 1801 Script Generated
+!system 1802 Fetch card pics
+!system 1803 Downloading
+!system 1804 No source url
 #victory reason
 !victory 0x0 投降
 !victory 0x1 基本分变成0

--- a/system.conf
+++ b/system.conf
@@ -48,6 +48,7 @@ window_maximized = 0
 window_width = 1536
 window_height = 960
 resize_popup_menu = 0
+pic_source_url = N
 enable_sound = 1
 enable_music = 1
 #Volume of sound and music, between 0 and 100


### PR DESCRIPTION
## Summary
This PR introduces an automated way to fetch missing card images and adds configurable image source support.

## Changes
- Added a new button in **deck config** that allows users to automatically download missing card images.
- Introduced a new option in **system config**:
  - `pic_source_url` — allows users to specify a custom image source.
  - Setting it to `N` disables this feature.
- Utilized string resources from `string.conf` (IDs 1802–1804).

## Notes / Limitations
- Currently tested only on Windows.
- Assumes the user environment includes the built-in Windows library `urlmon.dll`.