### PR TITLE
Move _IRR_STATIC_LIB_ to premake5.lua

### DIFF
--- a/gframe/CGUITTFont.cpp
+++ b/gframe/CGUITTFont.cpp
@@ -28,7 +28,6 @@
    john@suckerfreegames.com
 */
 
-#define _IRR_STATIC_LIB_
 #include <irrlicht.h>
 #include "CGUITTFont.h"
 

--- a/gframe/config.h
+++ b/gframe/config.h
@@ -5,7 +5,6 @@
 #define VERSION_MINOR 4
 #define VERSION_PATCH 0
 
-#define _IRR_STATIC_LIB_
 #define IRR_COMPILE_WITH_DX9_DEV_PACK
 
 #include <cerrno>

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -6,6 +6,7 @@ project "YGOPro"
     rtti "Off"
     openmp "On"
 
+    defines { "_IRR_STATIC_LIB_" }
     files { "*.cpp", "*.h" }
     includedirs { "../ocgcore" }
     links { "ocgcore", "clzma", LUA_LIB_NAME, "sqlite3", "irrlicht", "freetype", "event" }


### PR DESCRIPTION
IrrCompileConfig.h
```cpp
// To build Irrlicht as a static library, you must define _IRR_STATIC_LIB_ in both the
// Irrlicht build, *and* in the user application, before #including <irrlicht.h>
```