### PR TITLE
Change the genesys point separator to $%*[^ \t\n]

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -62,7 +62,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				continue;
 			uint32_t code = static_cast<uint32_t>(result);
 			int creditValue = 0;
-			if (std::sscanf(end, " $ %d", &creditValue) == 1 || std::sscanf(end, " $%*s %d", &creditValue) == 1) {
+			if (std::sscanf(end, " $%*[^ \t\n] %d", &creditValue) == 1) {
 				if (cur->pointList.empty())
 					continue;
 				if (creditValue <= 0)

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -46,7 +46,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			if(linebuf[0] == '$') {
 				int limitValue = 0;
 				char keybuf[256];
-				if (std::sscanf(linebuf, "$%255s %d", keybuf, &limitValue) != 2)
+				if (std::sscanf(linebuf, "$%255[^ \t\n] %d", keybuf, &limitValue) != 2)
 					continue;
 				if (limitValue < 0)
 					limitValue = 0;


### PR DESCRIPTION
5/31 update:
The separator is changed to `$%*[^ \t\n]`.
There should be at least 1 non-space character after `$`.


# Requirements
In order to simplify the parsing in LoadLFListSingle, the function has the following requirements:
- start with # 
Ignored

- start with !
Introduce a new `LFList` object

- $%255[^ \t\n] %d
Introduce a new GamePoint system in the current  `LFList`

- "%u %d"
Add a new card to the current `LFList` object.
It will be put in the current `LFList::content`,

- "%u $%*[^ \t\n] %d"
Add a new card to the CURRENT GamePoint system.
There should be at least 1 non-space character after $, and the string is read but ignored.
If a LFList has multiple GamePoint systems, all cards in the same GamePoint system should be written in the same section.


----
為了簡化 LoadLFListSingle 函數的解析，此函數有以下要求：

- 以 # 開頭
忽略

- $%255[^ \t\n] %d
引入一個新的 `LFList` 對象

- 以 $ 開頭
在目前 `LFList` 中引入一個新的 GamePoint 系統

- %u %d
向目前 `LFList` 物件新增一張新卡。
它將被放入目前 `LFList::content` 中。

- "%u $%*[^ \t\n] %d"
向目前 GamePoint 系統新增一張新卡。
$ 後面至少要有1個非空白字元，這個字串會被讀取但忽略。
如果一個 LFList 包含多個 GamePoint 系統，相同 GamePoint 系統中的所有卡片必須寫在相同區塊。