### PR TITLE
Support Genesys Point, part 2

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1815,6 +1815,8 @@ void DeckBuilder::pop_side(int seq) {
 	GetHoveredCard();
 }
 bool DeckBuilder::check_limit(const CardDataC* pointer) {
+	if ((pointer->type & TYPE_MONSTER) && (pointer->type & filterList->noMonsterType))
+		return false;
 	auto limitcode = pointer->get_duel_code();
 	int limit = 3;
 	auto flit = filterList->content.find(limitcode);

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -18,14 +18,18 @@ void DeckManager::LoadLFListSingle(const char* path) {
 	uint32_t pointHash{};
 	auto credit_hash = [](const char* s) -> uint32_t {
 		uint32_t h = 2166136261u;
-		for(auto p = s; *p; ++p) {
+		for (auto p = s; *p; ++p) {
 			h ^= static_cast<unsigned char>(*p);
 			h *= 16777619u;
 		}
 		return h;
 	};
 	auto credit_update_hash = [](uint32_t h, uint32_t a, uint32_t b, uint32_t c) -> uint32_t {
-		return h ^ ((a << 18) | (a >> 14)) ^ ((b << 9) | (b >> 23)) ^ ((c << 27) | (c >> 5));
+		uint32_t mix = a + 0x9e3779b9;
+		mix = (mix ^ b) * 0x85ebca6b;
+		mix = (mix ^ c) * 0xc2b2ae35;
+		mix ^= (mix >> 16);
+		return h ^ mix;
 	};
 	auto code_update_hash = [](uint32_t hash, uint32_t code, uint32_t count)-> uint32_t {
 		return hash ^ ((code << 18) | (code >> 14)) ^ ((code << (27 + count)) | (code >> (5 - count)));

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -15,6 +15,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 	FILE* fp = std::fopen(path, "r");
 	char linebuf[1024]{};
 	wchar_t strBuffer[256]{};
+	uint32_t pointHash{};
 	auto credit_hash = [](const char* s) -> uint32_t {
 		uint32_t h = 2166136261u;
 		for(auto p = s; *p; ++p) {
@@ -25,6 +26,9 @@ void DeckManager::LoadLFListSingle(const char* path) {
 	};
 	auto credit_update_hash = [](uint32_t h, uint32_t a, uint32_t b, uint32_t c) -> uint32_t {
 		return h ^ ((a << 18) | (a >> 14)) ^ ((b << 9) | (b >> 23)) ^ ((c << 27) | (c >> 5));
+	};
+	auto code_update_hash = [](uint32_t hash, uint32_t code, uint32_t count)-> uint32_t {
+		return hash ^ ((code << 18) | (code >> 14)) ^ ((code << (27 + count)) | (code >> (5 - count)));
 	};
 	if(fp) {
 		while(std::fgets(linebuf, sizeof linebuf, fp)) {
@@ -49,6 +53,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				if (errno || type > UINT32_MAX)
 					continue;
 				cur->noMonsterType = type;
+				cur->hash = code_update_hash(cur->hash, cur->noMonsterType, 3);
 				continue;
 			}
 			if(linebuf[0] == '$') {
@@ -59,7 +64,8 @@ void DeckManager::LoadLFListSingle(const char* path) {
 				if (limitValue < 0)
 					limitValue = 0;
 				cur->pointList.push_back({ keybuf, limitValue });
-				cur->hash = credit_update_hash(cur->hash, credit_hash(keybuf), static_cast<uint32_t>(limitValue), 0x43524544u);
+				pointHash = credit_hash(keybuf);
+				cur->hash = credit_update_hash(cur->hash, pointHash, static_cast<uint32_t>(limitValue), 0x43524544u);
 				continue;
 			}
 			char* pos = linebuf;
@@ -77,7 +83,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 					continue;
 				auto& point = cur->pointList.back();
 				point.table[code] = creditValue;
-				cur->hash = credit_update_hash(cur->hash, code, credit_hash(point.name.c_str()), static_cast<uint32_t>(creditValue));
+				cur->hash = credit_update_hash(cur->hash, code, pointHash, static_cast<uint32_t>(creditValue));
 				continue;
 			}
 			pos = end;
@@ -89,7 +95,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			if (count < 0 || count > 2)
 				continue;
 			cur->content[code] = count;
-			cur->hash = cur->hash ^ ((code << 18) | (code >> 14)) ^ ((code << (27 + count)) | (code >> (5 - count)));
+			cur->hash = code_update_hash(cur->hash, code, count);
 		}
 		std::fclose(fp);
 	}

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -33,7 +33,7 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			if(linebuf[0] == '!') {
 				auto len = std::strcspn(linebuf, "\r\n");
 				linebuf[len] = 0;
-				BufferIO::DecodeUTF8(&linebuf[1], strBuffer);
+				BufferIO::DecodeUTF8(linebuf + 1, strBuffer);
 				LFList newlist;
 				newlist.listName = strBuffer;
 				newlist.hash = 0x7dfcee6a;
@@ -43,6 +43,14 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			}
 			if (cur == _lfList.rend())
 				continue;
+			if (linebuf[0] == 'M' || linebuf[1] == ' ') {
+				errno = 0;
+				auto type = std::strtoul(linebuf + 2, nullptr, 16);
+				if (errno || type > UINT32_MAX)
+					continue;
+				cur->noMonsterType = type;
+				continue;
+			}
 			if(linebuf[0] == '$') {
 				int limitValue = 0;
 				char keybuf[256];
@@ -150,6 +158,8 @@ uint32_t DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, size_t ru
 		auto it = list.find(code);
 		if(it != list.end() && dc > it->second)
 			return (DECKERROR_LFLIST << 28) | cit->code;
+		if ((cit->type & TYPE_MONSTER) && (cit->type & lflist->noMonsterType))
+			return (DECKERROR_LFLIST << 28) | cit->code;
 	}
 	for (auto& cit : deck.extra) {
 		auto gameruleDeckError = checkAvail(cit->ot, avail);
@@ -165,6 +175,8 @@ uint32_t DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, size_t ru
 		auto it = list.find(code);
 		if(it != list.end() && dc > it->second)
 			return (DECKERROR_LFLIST << 28) | cit->code;
+		if ((cit->type & TYPE_MONSTER) && (cit->type & lflist->noMonsterType))
+			return (DECKERROR_LFLIST << 28) | cit->code;
 	}
 	for (auto& cit : deck.side) {
 		auto gameruleDeckError = checkAvail(cit->ot, avail);
@@ -179,6 +191,8 @@ uint32_t DeckManager::CheckDeck(const Deck& deck, unsigned int lfhash, size_t ru
 			return (DECKERROR_CARDCOUNT << 28) | cit->code;
 		auto it = list.find(code);
 		if(it != list.end() && dc > it->second)
+			return (DECKERROR_LFLIST << 28) | cit->code;
+		if ((cit->type & TYPE_MONSTER) && (cit->type & lflist->noMonsterType))
 			return (DECKERROR_LFLIST << 28) | cit->code;
 	}
 	std::vector<int> sum = GetDeckPoint(deck, lflist);

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -47,12 +47,12 @@ void DeckManager::LoadLFListSingle(const char* path) {
 			}
 			if (cur == _lfList.rend())
 				continue;
-			if (linebuf[0] == 'M' || linebuf[1] == ' ') {
+			if (linebuf[0] == 'M' && linebuf[1] == ' ') {
 				errno = 0;
 				auto type = std::strtoul(linebuf + 2, nullptr, 16);
 				if (errno || type > UINT32_MAX)
 					continue;
-				cur->noMonsterType = type;
+				cur->noMonsterType = static_cast<uint32_t>(type);
 				cur->hash = code_update_hash(cur->hash, cur->noMonsterType, 3);
 				continue;
 			}

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -30,12 +30,13 @@ constexpr int DECK_CATEGORY_CUSTOM = 4;
 
 struct GamePoint {
 	std::string name;
-	int limit;
+	int limit{};
 	std::unordered_map<uint32_t, int> table;
 };
 
 struct LFList {
 	unsigned int hash{};
+	uint32_t noMonsterType{};
 	std::wstring listName;
 	std::unordered_map<uint32_t, int> content;
 	std::vector<GamePoint> pointList;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1164,38 +1164,39 @@ void Game::DrawThumb(const CardDataC* cp, irr::core::vector2di pos, const LFList
 	driver->draw2DImage(img, dragloc, irr::core::rect<irr::s32>(0, 0, size.Width, size.Height));
 	auto current_limitloc = limitloc;
 	auto credit_max_display = CARD_THUMB_WIDTH / 20;
-	auto next_limitloc = [&]() {
-		auto this_limitloc = current_limitloc;
+	auto advance_icon_slot = [&]() {
 		auto width = current_limitloc.getWidth();
 		current_limitloc.UpperLeftCorner.X += width;
 		current_limitloc.LowerRightCorner.X += width;
 		--credit_max_display;
-		return this_limitloc;
 	};
 	auto lfit = lflist->content.find(lcode);
-	if (lfit != lflist->content.end() && lfit->second >= 0 && lfit->second <= 2) {
+	int count = lfit != lflist->content.end() ? lfit->second : 3;
+	if (count >= 0 && count <= 2) {
 		auto lim_texture_offset_x = 0;
 		auto lim_texture_offset_y = 0;
-		if(lfit->second == 1) {
+		if(count == 1) {
 			lim_texture_offset_x = 64;
-		} else if(lfit->second == 2) {
+		} else if(count == 2) {
 			lim_texture_offset_y = 64;
 		}
-		driver->draw2DImage(imageManager.tLim, next_limitloc(), irr::core::recti(lim_texture_offset_x, lim_texture_offset_y, lim_texture_offset_x + 64, lim_texture_offset_y + 64), 0, 0, true);
+		driver->draw2DImage(imageManager.tLim, current_limitloc, irr::core::recti(lim_texture_offset_x, lim_texture_offset_y, lim_texture_offset_x + 64, lim_texture_offset_y + 64), 0, 0, true);
+		advance_icon_slot();
 	}
 	for (auto& point : lflist->pointList) {
 		auto it = point.table.find(original_code);
 		if (it == point.table.end())
 			continue;
 		auto value = it->second;
-		if (value > 0 && value <= 100) {
+		if (value >= 1 && value <= 100) {
 			auto cvalue = value - 1; // 1-100 => 0-99
 			// pick the first and second digit
 			auto digit1 = cvalue / 10;
 			auto digit2 = cvalue % 10;
 			auto credit_texture_offset_x = digit2 * 64;
 			auto credit_texture_offset_y = digit1 * 64;
-			driver->draw2DImage(imageManager.tLimCredit, next_limitloc(), irr::core::recti(credit_texture_offset_x, credit_texture_offset_y, credit_texture_offset_x + 64, credit_texture_offset_y + 64), 0, 0, true);
+			driver->draw2DImage(imageManager.tLimCredit, current_limitloc, irr::core::recti(credit_texture_offset_x, credit_texture_offset_y, credit_texture_offset_x + 64, credit_texture_offset_y + 64), 0, 0, true);
+			advance_icon_slot();
 		}
 		if (credit_max_display <= 0)
 			break;

--- a/gframe/drawing.cpp
+++ b/gframe/drawing.cpp
@@ -1172,6 +1172,8 @@ void Game::DrawThumb(const CardDataC* cp, irr::core::vector2di pos, const LFList
 	};
 	auto lfit = lflist->content.find(lcode);
 	int count = lfit != lflist->content.end() ? lfit->second : 3;
+	if ((cp->type & TYPE_MONSTER) && (cp->type & lflist->noMonsterType))
+		count = 0;
 	if (count >= 0 && count <= 2) {
 		auto lim_texture_offset_x = 0;
 		auto lim_texture_offset_y = 0;


### PR DESCRIPTION
# Requirements
In order to simplify the parsing in LoadLFListSingle, the function has the following requirements:
- start with `#`
Ignored

- start with `!`
Introduce a new `LFList` object

- start with `M `
Ban specific monster types.
It will be used in Genesys Point.

- $%255[^ \t\n] %d
Introduce a new GamePoint system in the current  `LFList`

- %u %d
Add a new card to the current `LFList` object.
It will be put in the current `LFList::content`,

- %u $%*[^ \t\n] %d
Add a new card to the CURRENT GamePoint system.
There should be at least 1 non-space character after $, and the string is read but ignored.
If a LFList has multiple GamePoint systems, all cards in the same GamePoint system should be written in the same section.


----
為了簡化 LoadLFListSingle 函數的解析，此函數有以下要求：

- 以`#開頭
忽略

- 以`!`開頭
引入一個新的 `LFList` 對象

- 以`M `開頭
禁用特定的怪獸類型
Genesys Point會用到

- $%255[^ \t\n] %d
在目前 `LFList` 中引入一個新的 GamePoint 系統

- %u %d
向目前 `LFList` 物件新增一張新卡。
它將被放入目前 `LFList::content` 中。

- %u $%*[^ \t\n] %d
向目前 GamePoint 系統新增一張新卡。
$ 後面至少要有1個非空白字元，這個字串會被讀取但忽略。
如果一個 LFList 包含多個 GamePoint 系統，相同 GamePoint 系統中的所有卡片必須寫在相同區塊。

# Hash function
Suppose there are 2 point tables:
```
# point table 1
$A 100
100 $A 10
200 $A 20
```
```
# point table 2
$A 100
100 $A 20
200 $A 10
```


## The old hash function:
```cpp
auto credit_update_hash = [](uint32_t h, uint32_t a, uint32_t b, uint32_t c) -> uint32_t {
		return h ^ ((a << 18) | (a >> 14)) ^ ((b << 9) | (b >> 23)) ^ ((c << 27) | (c >> 5));
	};
cur->hash = credit_update_hash(cur->hash, code, pointHash, static_cast<uint32_t>(creditValue));
```

a, b, c are combined by XOR.
Calculating c=20 and then c=10 is the same as calculating c=10 and then c=20.
The 2 different table have the same hash value.

## The new hash function
It is suggested by Gemini.
```cpp
auto credit_update_hash = [](uint32_t h, uint32_t a, uint32_t b, uint32_t c) -> uint32_t {
		uint32_t mix = a + 0x9e3779b9;
		mix = (mix ^ b) * 0x85ebca6b;
		mix = (mix ^ c) * 0xc2b2ae35;
		mix ^= (mix >> 16);
		return h ^ mix;
	};
cur->hash = credit_update_hash(cur->hash, code, pointHash, static_cast<uint32_t>(creditValue));
```
2 tables with different point have different hash values.
