### PR TITLE
Refactor EncodeUTF8String and DecodeUTF8String

### DIFF
--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -123,17 +123,17 @@ public:
 		return true;
 	}
 	// UTF-16/UTF-32 to UTF-8
-	static std::string EncodeUTF8String(const std::wstring& wstr) {
-		if (wstr.empty())
+	static std::string EncodeUTF8String(const wchar_t* wstr) {
+		if (*wstr == L'\0')
 			return std::string();
 		std::mbstate_t state{};
-		const wchar_t* src = wstr.c_str();
+		const wchar_t* src = wstr;
 		size_t len = std::wcsrtombs(nullptr, &src, 0, &state);
 		if (len == static_cast<size_t>(-1))
 			return std::string();
 		std::string result(len, '\0');
 		state = std::mbstate_t{};
-		src = wstr.c_str();
+		src = wstr;
 		std::wcsrtombs(&result[0], &src, len, &state);
 		return result;
 	}
@@ -150,17 +150,17 @@ public:
 		return static_cast<int>(result_len);
 	}
 	// UTF-8 to UTF-16/UTF-32
-	static std::wstring DecodeUTF8String(const std::string& str) {
-		if (str.empty())
+	static std::wstring DecodeUTF8String(const char* str) {
+		if (*str == '\0')
 			return std::wstring();
 		std::mbstate_t state{};
-		const char* src = str.c_str();
+		const char* src = str;
 		size_t len = std::mbsrtowcs(nullptr, &src, 0, &state);
 		if (len == static_cast<size_t>(-1))
 			return std::wstring();
 		std::wstring result(len, L'\0');
 		state = std::mbstate_t{};
-		src = str.c_str();
+		src = str;
 		std::mbsrtowcs(&result[0], &src, len, &state);
 		return result;
 	}

--- a/gframe/bufferio.h
+++ b/gframe/bufferio.h
@@ -124,14 +124,15 @@ public:
 	}
 	// UTF-16/UTF-32 to UTF-8
 	static std::string EncodeUTF8String(const wchar_t* wstr) {
+		std::string result;
 		if (*wstr == L'\0')
-			return std::string();
+			return result;
 		std::mbstate_t state{};
 		const wchar_t* src = wstr;
 		size_t len = std::wcsrtombs(nullptr, &src, 0, &state);
 		if (len == static_cast<size_t>(-1))
-			return std::string();
-		std::string result(len, '\0');
+			return result;
+		result.resize(len);
 		state = std::mbstate_t{};
 		src = wstr;
 		std::wcsrtombs(&result[0], &src, len, &state);
@@ -151,14 +152,15 @@ public:
 	}
 	// UTF-8 to UTF-16/UTF-32
 	static std::wstring DecodeUTF8String(const char* str) {
+		std::wstring result;
 		if (*str == '\0')
-			return std::wstring();
+			return result;
 		std::mbstate_t state{};
 		const char* src = str;
 		size_t len = std::mbsrtowcs(nullptr, &src, 0, &state);
 		if (len == static_cast<size_t>(-1))
-			return std::wstring();
-		std::wstring result(len, L'\0');
+			return result;
+		result.resize(len);
 		state = std::mbstate_t{};
 		src = str;
 		std::mbsrtowcs(&result[0], &src, len, &state);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -2527,12 +2527,12 @@ bool Game::SpawnAsync(const std::wstring& exePath, const std::vector<std::wstrin
 	CloseHandle(pi.hProcess);
 	return true;
 #else
-	std::string exePathUTF8 = BufferIO::EncodeUTF8String(exePath);
+	std::string exePathUTF8 = BufferIO::EncodeUTF8String(exePath.data());
 
 	std::vector<std::string> utf8Args;
 	utf8Args.emplace_back(exePathUTF8);
 	for (const auto& arg : args) {
-		utf8Args.push_back(BufferIO::EncodeUTF8String(arg));
+		utf8Args.push_back(BufferIO::EncodeUTF8String(arg.data()));
 	}
 
 	std::vector<char*> execArgs;

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -26,7 +26,7 @@ void ClickButton(irr::gui::IGUIElement* btn) {
 	ygo::mainGame->device->postEventFromUser(event);
 }
 
-static int mymain(int wargc, const wchar_t* const wargv[]) {
+static int mymain(int wargc, wchar_t* wargv[]) {
 #ifdef __APPLE__
 	ygo::Game::FixMacOSBundleWorkingDirectory();
 #endif //__APPLE__
@@ -192,11 +192,11 @@ int main(int argc, char* argv[]) {
 	std::vector<std::wstring> wide_arguments;
 	wide_arguments.reserve(argc);
 	for(int i = 0; i < argc; ++i)
-		wide_arguments.emplace_back(BufferIO::DecodeUTF8String(argv[i]));
-	std::vector<const wchar_t*> wargv;
+		wide_arguments.push_back(BufferIO::DecodeUTF8String(argv[i]));
+	std::vector<wchar_t*> wargv;
 	wargv.reserve(argc);
-	for(const auto& argument : wide_arguments)
-		wargv.emplace_back(argument.c_str());
+	for(auto& argument : wide_arguments)
+		wargv.push_back(argument.data());
 	return mymain(argc, wargv.data());
 }
 


### PR DESCRIPTION

```cpp
static std::string EncodeUTF8String(const wchar_t* wstr);
static std::wstring DecodeUTF8String(const char* str);
```
Implicit conversion to std::string, std::wstring is unnecessary.
